### PR TITLE
Fix mono font issue in "Literate Programming" section

### DIFF
--- a/3ed-2018/Introduction/Literate_Programming.html
+++ b/3ed-2018/Introduction/Literate_Programming.html
@@ -220,7 +220,7 @@ write a complicated function as a series of fragments:
         &lt;&lt;<span class="fragmentname">Swap parameter values</span>&gt;&gt;
     }
     &lt;&lt;<span class="fragmentname">Do precomputation before loop</span>&gt;&gt;
-    &lt;&lt;<span class="fragmentname">Loop through and update \mono{values} array</span>&gt;&gt;
+    &lt;&lt;<span class="fragmentname">Loop through and update </span>values<span class="fragmentname"></span> array</span>&gt;&gt;
 }</div><p>
 
 

--- a/3ed-2018/Introduction/Literate_Programming.html
+++ b/3ed-2018/Introduction/Literate_Programming.html
@@ -220,7 +220,7 @@ write a complicated function as a series of fragments:
         &lt;&lt;<span class="fragmentname">Swap parameter values</span>&gt;&gt;
     }
     &lt;&lt;<span class="fragmentname">Do precomputation before loop</span>&gt;&gt;
-    &lt;&lt;<span class="fragmentname">Loop through and update </span>values<span class="fragmentname"></span> array</span>&gt;&gt;
+    &lt;&lt;<span class="fragmentname">Loop through and update </span>values<span class="fragmentname"> array</span>&gt;&gt;
 }</div><p>
 
 


### PR DESCRIPTION
I've noticed an issue with how the mono font was being rendered in the "Literate Programming" section.
Here is how it looked before:
![image](https://user-images.githubusercontent.com/10166340/183267862-9e1f6691-8073-4052-bfd4-b96fe4e15768.png)
Here is how it looks now:
![image](https://user-images.githubusercontent.com/10166340/183267866-6d131228-1fe4-4107-bc85-fa3aa6929388.png)
