### PR TITLE
(Typo) Remove subscript in the variance of the overall estimator

### DIFF
--- a/4ed/Monte_Carlo_Integration/Improving_Efficiency.html
+++ b/4ed/Monte_Carlo_Integration/Improving_Efficiency.html
@@ -884,7 +884,7 @@ variance of the overall estimator&nbsp;is
 </div>
 <div class="col-md-10 col-lg-8">
 <div class="displaymath"><svg xmlns:xlink="http://www.w3.org/1999/xlink" width="20.595ex" height="5.176ex" style="vertical-align: -1.838ex;" viewBox="0 -1437.2 8867.4 2228.5" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
-<title id="MathJax-SVG-1-Title">upper V left-bracket upper F Subscript n Baseline right-bracket equals StartFraction 1 Over n EndFraction sigma-summation v Subscript i Baseline sigma Subscript i Superscript 2 Baseline period</title>
+<title id="MathJax-SVG-1-Title">upper V left-bracket upper F right-bracket equals StartFraction 1 Over n EndFraction sigma-summation v Subscript i Baseline sigma Subscript i Superscript 2 Baseline period</title>
 <defs aria-hidden="true">
 <path stroke-width="1" id="E1-LATINMODERNNORMAL-1D449" d="M769 671c0 0 -1 -18 -13 -19c-37 -2 -79 -5 -128 -83l-360 -573c-8 -13 -12 -18 -28 -18c-13 0 -17 3 -20 23l-79 617c-3 25 -4 34 -60 34c-16 0 -25 0 -25 12c0 19 12 19 19 19c17 0 36 -2 54 -2s37 -1 55 -1c41 0 84 3 124 3c6 0 14 -2 14 -11c0 -20 -11 -20 -25 -20 c-46 0 -69 -13 -69 -30l68 -529l307 488s15 23 15 38c0 21 -19 31 -46 33c-7 0 -16 1 -16 12c0 19 13 19 19 19c32 0 66 -3 99 -3c27 0 56 3 82 3c8 0 13 -4 13 -12Z"></path>
 <path stroke-width="1" id="E1-LATINMODERNMAIN-5B" d="M256 -230c0 -11 -9 -20 -20 -20h-122v1000h122c11 0 20 -9 20 -20s-9 -20 -20 -20h-82v-920h82c11 0 20 -9 20 -20Z"></path>


### PR DESCRIPTION
I think there is a small typo in the equation of the variance
There is a subscript in the estimator suggesting that it would be the estimator for a stratum, while the text is telling us that it is the formula for the **overall estimator**

The screenshot below shows the subscript to be removed

https://pbr-book.org/4ed/Monte_Carlo_Integration/Improving_Efficiency#StratifiedSampling

<img width="1045" alt="image" src="https://github.com/mmp/pbr-book-website/assets/13306328/2ee5a33e-b3e0-4d2c-bae4-50fafef8f966">
