### PR TITLE
Typo in the triangle meshes page (relation between number of edges and number of faces

### DIFF
--- a/4ed/Shapes/Triangle_Meshes.html
+++ b/4ed/Shapes/Triangle_Meshes.html
@@ -206,7 +206,7 @@ where <svg xmlns:xlink="http://www.w3.org/1999/xlink" width="6.041ex" height="2.
 </svg> is the <em>genus</em> of the mesh. The genus is usually a
 small number and can be interpreted as the number of &ldquo;handles&rdquo; in the mesh
 (analogous to a handle of a teacup). On a triangle mesh, the number of edges and
-vertices is furthermore related by the identity
+faces is furthermore related by the identity
 </p>
 
 </div> <!-- col-md-10 col-lg-8 -->


### PR DESCRIPTION
The typo is in this section https://pbr-book.org/4ed/Shapes/Triangle_Meshes#

The equation gives the relation between the number of edges and <ins>faces</ins>, but the text says it is between edges and <ins>vertices</ins>

<img width="477" alt="image" src="https://github.com/mmp/pbr-book-website/assets/13306328/f74617ae-a682-4409-b4f7-403f61c00dc6">
